### PR TITLE
feat(brand/web): IKEA palette + League Spartan; update CTAs and links

### DIFF
--- a/web/app/generate/page.tsx
+++ b/web/app/generate/page.tsx
@@ -102,7 +102,7 @@ export default function GenerateLessonPage() {
 
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Generate Lesson from Hugging Face URL</h1>
+      <h1 className="text-2xl font-black font-display">Generate Lesson from Hugging Face URL</h1>
       <form onSubmit={onSubmit} className="space-y-3">
         <input
           className="w-full p-2 rounded bg-gray-900 border border-gray-800"
@@ -165,7 +165,10 @@ export default function GenerateLessonPage() {
           <span className="text-xs text-gray-500">Hint: For Local, install Ollama and run <code>ollama pull gpt-oss:20b</code>. See README.</span>
         </div>
         <div className="flex gap-2">
-          <button className="brand-cta disabled:opacity-50" disabled={loading || !hfUrl.trim()}>
+          <button
+            className="inline-block bg-ikea-yellow text-ink border border-ink rounded-brand px-3 py-2 disabled:opacity-50"
+            disabled={loading || !hfUrl.trim()}
+          >
             {loading ? "Generating..." : "Generate Lesson"}
           </button>
           <button
@@ -250,8 +253,8 @@ export default function GenerateLessonPage() {
               <div className="font-medium text-gray-200 mb-1">Model Maker</div>
               <div>{result.preview.model_maker.name} ({result.preview.model_maker.org_type})</div>
               <div className="flex gap-2 mt-1">
-                {result.preview.model_maker.homepage && <a className="text-blue-400 hover:underline" href={result.preview.model_maker.homepage} target="_blank">Homepage</a>}
-                {result.preview.model_maker.repo && <a className="text-blue-400 hover:underline" href={result.preview.model_maker.repo} target="_blank">Repo</a>}
+                {result.preview.model_maker.homepage && <a className="text-ikea-blue hover:underline" href={result.preview.model_maker.homepage} target="_blank">Homepage</a>}
+                {result.preview.model_maker.repo && <a className="text-ikea-blue hover:underline" href={result.preview.model_maker.repo} target="_blank">Repo</a>}
                 {result.preview.model_maker.license && <span className="text-gray-400">License: {result.preview.model_maker.license}</span>}
               </div>
             </div>
@@ -272,7 +275,7 @@ export default function GenerateLessonPage() {
           )}
           <div className="flex gap-2">
             <button
-              className="px-3 py-2 rounded bg-blue-600 text-white"
+              className="px-3 py-2 rounded-brand bg-ikea-blue text-white hover:brightness-95"
               onClick={() => { window.location.href = `/tutorial/${result.tutorialId}`; }}
             >
               Open Tutorial

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,16 +1,16 @@
 @import "tailwindcss/preflight";
 @tailwind utilities;
 
-/* ALAIN brand tokens — Code meets Seinfeld */
+/* Web fonts: League Spartan (Google Fonts) */
+@import url('https://fonts.googleapis.com/css2?family=League+Spartan:wght@700;900&display=swap');
+
+/* IKEA-inspired brand tokens */
 :root {
   /* Brand core */
-  --alain-yolk: #FFD22E;
-  --alain-yolk-shadow: #FFB800;
-  --alain-paper: #FFF6D1;
-  --alain-red: #C33228;
-  --alain-red-shadow: #8E221C;
-  --alain-ink: #1B1B1B;
-  --alain-blue: #2CA6A4;
+  --ikea-blue: #0057AD;
+  --ikea-yellow: #FBDA0C;
+  --paper: #FFFFFF; /* consider #FFFAEF for warm docs */
+  --ink: #111827;
 
   /* UI neutrals */
   --text-strong: #0F172A;
@@ -23,17 +23,17 @@
   --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
 }
 
-/* Simple helpers to reuse tokens without Tailwind config changes */
+/* Simple helpers using tokens */
 .brand-header {
   background: var(--bg);
   color: var(--text-strong);
-  border-bottom: 1px solid color-mix(in srgb, var(--alain-ink) 12%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--ink) 12%, transparent);
 }
 
 .brand-cta {
-  background: var(--alain-yolk);
-  color: var(--alain-ink);
-  border: 1px solid var(--alain-ink);
+  background: var(--ikea-yellow);
+  color: var(--ink);
+  border: 1px solid var(--ink);
   border-radius: var(--radius);
   padding: 0.4rem 0.8rem;
 }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -49,8 +49,8 @@ export default function RootLayout({
             </SignedOut>
             <SignedIn>
               <div className="flex items-center gap-3">
-                <Link href="/tutorials" className="text-sm text-blue-600 hover:underline">Tutorials</Link>
-                <Link href="/settings" className="text-sm text-blue-600 hover:underline">Settings</Link>
+                <Link href="/tutorials" className="text-sm text-ikea-blue hover:underline">Tutorials</Link>
+                <Link href="/settings" className="text-sm text-ikea-blue hover:underline">Settings</Link>
                 <UserButton />
               </div>
             </SignedIn>

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -82,7 +82,7 @@ export default function SettingsPage() {
                     {p.notes && <div className="text-xs text-gray-500">{p.notes}</div>}
                   </div>
                   <div className="flex items-center gap-2">
-                    <button onClick={() => validate(p.id)} className="px-3 py-1 rounded bg-blue-600 text-white">
+                    <button onClick={() => validate(p.id)} className="px-3 py-1 rounded-brand bg-ikea-blue text-white hover:brightness-95">
                       Validate
                     </button>
                     <button

--- a/web/app/tutorials/page.tsx
+++ b/web/app/tutorials/page.tsx
@@ -48,6 +48,8 @@ type FilterState = {
 export default function TutorialsPage() {
   const [data, setData] = useState<TutorialsResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [seeding, setSeeding] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
   const [filters, setFilters] = useState<FilterState>({
     difficulty: "",
     provider: "",
@@ -139,12 +141,43 @@ export default function TutorialsPage() {
     <div className="max-w-5xl mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-3xl font-bold">Tutorials</h1>
-        {data && (
-          <span className="text-sm text-gray-400">
-            {data.pagination.total} tutorials
-          </span>
-        )}
+        <div className="flex items-center gap-3">
+          {data && (
+            <span className="text-sm text-gray-400">
+              {data.pagination.total} tutorials
+            </span>
+          )}
+          <button
+            onClick={async ()=>{
+              try {
+                setSeeding(true);
+                setNotice(null);
+                const base = process.env.NEXT_PUBLIC_BACKEND_BASE || "http://localhost:4000";
+                const res = await fetch(`${base}/seed`, { method: 'POST' });
+                const j = await res.json().catch(()=>({}));
+                if (j?.inserted) {
+                  setNotice('Sample lessons loaded');
+                } else {
+                  setNotice('Samples already present');
+                }
+                await loadTutorials(1);
+              } catch (e) {
+                setNotice('Failed to load samples');
+              } finally {
+                setSeeding(false);
+                setTimeout(()=> setNotice(null), 2500);
+              }
+            }}
+            disabled={seeding}
+            className="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded text-sm disabled:opacity-50"
+            title="Insert curated sample tutorials if none exist"
+          >{seeding ? 'Loading…' : 'Load Sample'}</button>
+        </div>
       </div>
+
+      {notice && (
+        <div className="text-sm text-gray-300 bg-gray-900 border border-gray-800 rounded px-3 py-2">{notice}</div>
+      )}
 
       {/* Search and Filters */}
       <div className="bg-gray-900 rounded-lg p-4 space-y-4">
@@ -159,7 +192,7 @@ export default function TutorialsPage() {
           />
           <button
             onClick={() => loadTutorials(1)}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+            className="px-4 py-2 bg-ikea-blue hover:brightness-95 text-white rounded-brand"
           >
             Search
           </button>
@@ -288,7 +321,7 @@ export default function TutorialsPage() {
 
             <a
               href={`/tutorial/${tutorial.id}`}
-              className="inline-block px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded transition-colors"
+              className="inline-block px-4 py-2 bg-ikea-blue hover:brightness-95 text-white rounded-brand transition-colors"
             >
               Start Tutorial
             </a>
@@ -329,7 +362,7 @@ export default function TutorialsPage() {
           <p className="text-gray-400 mb-4">Try adjusting your filters or search terms</p>
           <button
             onClick={clearFilters}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded"
+            className="px-4 py-2 bg-ikea-blue hover:brightness-95 text-white rounded-brand"
           >
             Clear Filters
           </button>

--- a/web/components/PromptCell.tsx
+++ b/web/components/PromptCell.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+/**
+ * PromptCell
+ * - Renders a Monaco editor (with textarea fallback) for prompt editing
+ * - Controlled via `codeTemplate`; emits changes via `onChange`
+ * - Shows a primary action button via `onExecute`
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  codeTemplate: string;
+  onChange?: (value: string) => void;
+  onExecute?: () => void;
+  disabled?: boolean;
+};
+
+export function PromptCell({ codeTemplate, onChange, onExecute, disabled }: Props) {
+  const monacoRef = useRef<HTMLDivElement | null>(null);
+  const editorRef = useRef<any>(null);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let disposed = false;
+    async function init() {
+      if (!monacoRef.current || editorRef.current) return;
+      try {
+        const monaco = await import("monaco-editor");
+        if (disposed) return;
+        editorRef.current = monaco.editor.create(monacoRef.current!, {
+          value: codeTemplate || "",
+          language: "markdown",
+          theme: "vs-dark",
+          automaticLayout: true,
+          minimap: { enabled: false },
+        });
+        editorRef.current.onDidChangeModelContent(() => {
+          const v = editorRef.current.getValue();
+          onChange?.(v);
+        });
+        setReady(true);
+      } catch {
+        setReady(false);
+      }
+    }
+    init();
+    return () => {
+      disposed = true;
+      if (editorRef.current) {
+        editorRef.current.dispose();
+        editorRef.current = null;
+      }
+    };
+  }, [codeTemplate, onChange]);
+
+  // Keep editor content in sync when parent changes codeTemplate
+  useEffect(() => {
+    if (editorRef.current && typeof codeTemplate === 'string') {
+      try {
+        const current = editorRef.current.getValue();
+        if (current !== codeTemplate) {
+          editorRef.current.setValue(codeTemplate);
+        }
+      } catch {}
+    }
+  }, [codeTemplate]);
+
+  return (
+    <div className="space-y-2">
+      <div ref={monacoRef} className="h-48 border border-gray-800 rounded" style={{ display: ready ? "block" : "none" }} />
+      {!ready && (
+        <textarea
+          className="w-full min-h-32 p-3 bg-gray-900 rounded border border-gray-800 focus:border-blue-500 focus:outline-none"
+          value={codeTemplate}
+          onChange={(e) => { onChange?.(e.target.value); }}
+          placeholder="Enter your prompt here..."
+        />
+      )}
+      <div>
+        <button
+          className="px-4 py-2 rounded-brand bg-ikea-blue hover:brightness-95 text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          onClick={onExecute}
+          disabled={disabled}
+        >
+          Run step
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/components/StepNav.tsx
+++ b/web/components/StepNav.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+/**
+ * StepNav
+ * - Minimal step navigation control with current index highlighting
+ */
+
+type Step = { id: number; step_order: number; title: string };
+
+type Props = {
+  steps: Step[];
+  currentStep: number; // index
+  onStepChange: (index: number) => void;
+};
+
+export function StepNav({ steps, currentStep, onStepChange }: Props) {
+  if (!steps?.length) return null;
+  return (
+    <div className="flex gap-2 mt-2">
+      {steps.map((s, i) => (
+        <button
+          key={s.id}
+          className={`px-3 py-1 rounded ${i === currentStep ? "bg-blue-600 text-white" : "bg-gray-800"}`}
+          onClick={() => onStepChange(i)}
+        >
+          Step {i + 1}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/components/StreamingOutput.tsx
+++ b/web/components/StreamingOutput.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * StreamingOutput
+ * - Displays streamed output with optional error banner and simple metrics
+ * - Accepts preformatted `output` string; no internal formatting is applied
+ */
+
+type Props = {
+  output: string;
+  isStreaming?: boolean;
+  error?: { code: string; message: string } | null;
+  elapsedSeconds?: number;
+  tokenCount?: number;
+};
+
+export function StreamingOutput({ output, isStreaming, error, elapsedSeconds, tokenCount }: Props) {
+  return (
+    <div className="space-y-2">
+      {error && (
+        <div className="bg-red-900/20 border border-red-700 rounded-lg p-3">
+          <div className="font-semibold text-red-400">{error.code}</div>
+          <div className="text-sm text-red-300">{error.message}</div>
+        </div>
+      )}
+
+      {isStreaming && !error && (
+        <div className="bg-gray-900 rounded p-3 text-sm space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-300">Elapsed:</span>
+            <span className="text-ikea-blue font-mono">{Math.max(0, elapsedSeconds || 0)}s</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-gray-300">Tokens:</span>
+            <span className="text-ikea-blue font-mono">~{tokenCount || 0}</span>
+          </div>
+          <div className="w-full bg-gray-700 rounded-full h-2">
+            <div className="bg-ikea-blue h-2 rounded-full animate-pulse" style={{ width: "60%" }} />
+          </div>
+        </div>
+      )}
+
+      <pre className="whitespace-pre-wrap bg-gray-900 border border-gray-800 rounded p-3 text-gray-100 text-sm min-h-24">
+        {output || (isStreaming ? "Streaming…" : "")}
+      </pre>
+    </div>
+  );
+}

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -1,9 +1,65 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}"]
-    ,
-  theme: { extend: {} },
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // IKEA-inspired brand colors
+        ikea: {
+          blue: "#0057AD",   // IKEA Blue
+          yellow: "#FBDA0C", // IKEA Yellow
+        },
+        ink: "#111827",      // Neutral ink for text/outlines
+        paper: "#FFFFFF",    // Default paper (use #FFFAEF if you want warm docs)
+      },
+      fontFamily: {
+        // Display/wordmark stack: League Spartan (Google Font)
+        display: [
+          "League Spartan",
+          "Inter",
+          "ui-sans-serif",
+          "system-ui",
+          "-apple-system",
+          "Segoe UI",
+          "Helvetica Neue",
+          "Arial",
+          "sans-serif",
+        ],
+        // App UI default stack
+        sans: [
+          "Inter",
+          "ui-sans-serif",
+          "system-ui",
+          "-apple-system",
+          "Segoe UI",
+          "Helvetica Neue",
+          "Arial",
+          "sans-serif",
+        ],
+        mono: [
+          "JetBrains Mono",
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Monaco",
+          "Consolas",
+          "Liberation Mono",
+          "Courier New",
+          "monospace",
+        ],
+      },
+      borderRadius: {
+        brand: "12px", // for pills/tabs/buttons
+        tab: "10px",
+      },
+      boxShadow: {
+        brand: "0 1px 2px rgba(15, 23, 42, 0.06)",
+      },
+    },
+  },
   plugins: [],
 } satisfies Config;
-


### PR DESCRIPTION
This PR pivots the web UI to an IKEA-inspired brand system and League Spartan for display typography.\n\nChanges\n- Tailwind: add ikea.blue/yellow, ink, paper; font stacks for display/sans/mono\n- Fonts: load League Spartan (700/900) via Google Fonts in globals.css\n- Tokens: replace brand tokens in globals.css with IKEA palette (blue/yellow/ink/paper)\n- Header: links use text-ikea-blue\n- CTAs: primary buttons use bg-ikea-blue; hero/form CTA uses bg-ikea-yellow with ink border\n- Headings: example H1 uses font-display font-black\n\nNotes\n- Futura removed; League Spartan is open-source and safer for open-source distribution\n- Legal: palette matches IKEA hues; if you want to reduce trade dress risk, we can shift hues slightly and avoid oval lockups in mark usage.\n\nScreens/Files\n- web/tailwind.config.ts\n- web/app/globals.css\n- web/app/layout.tsx\n- web/app/generate/page.tsx\n- web/app/settings/page.tsx\n- web/app/tutorial/[id]/page.tsx\n- web/app/tutorials/page.tsx\n- web/components/{PromptCell,StreamingOutput,StepNav}.tsx

## Summary by Sourcery

Pivot the web UI to an IKEA-inspired brand system by extending Tailwind with IKEA palette and League Spartan typography, refactoring tutorial UI into reusable components, and updating CTAs, links, and styling across the app.

New Features:
- Introduce IKEA-inspired theme with new color palette (ikea-blue, ikea-yellow, ink, paper) and font families (including League Spartan)
- Add PromptCell, StreamingOutput, and StepNav components for prompt editing, streaming output, and step navigation
- Add “Load Sample” button in tutorials page to seed sample tutorials via API

Enhancements:
- Refactor TutorialPage to replace inline Monaco setup and execution UI with PromptCell and StreamingOutput components
- Update CTAs, links, headers, and buttons across pages to use new ikea brand colors and font-display styles