### PR TITLE
fix(encore): require explicit db in buildSnapshot to satisfy compiler

### DIFF
--- a/backend/tutorials/versioning.ts
+++ b/backend/tutorials/versioning.ts
@@ -90,13 +90,12 @@ export const restoreVersion = api<{ tutorialId: number; version: number }, { res
   }
 );
 
-async function buildSnapshot(tutorialId: number, db?: any): Promise<any> {
-  const database = db ?? tutorialsDB;
-  const tutorial = await database.queryRow<any>`
+async function buildSnapshot(tutorialId: number, db: any): Promise<any> {
+  const tutorial = await db.queryRow<any>`
     SELECT id, title, description, model, provider, difficulty, tags, model_maker_id, created_at, updated_at
     FROM tutorials WHERE id = ${tutorialId}
   `;
-  const steps = await database.queryAll<any>`
+  const steps = await db.queryAll<any>`
     SELECT step_order, title, content, code_template, expected_output, model_params
     FROM tutorial_steps WHERE tutorial_id = ${tutorialId}
     ORDER BY step_order


### PR DESCRIPTION
Encore compiler flagged use of a database resource in a fallback expression (db ?? tutorialsDB).\n\nChange\n- backend/tutorials/versioning.ts: buildSnapshot now requires an explicit db param; all call sites already pass a transaction (tx).\n\nVerification\n- Backend tests pass locally (vitest).\n\nImpact\n- No behavior change; satisfies Encore deployment requirements.

## Summary by Sourcery

Bug Fixes:
- Change buildSnapshot signature to require a db parameter and eliminate the fallback to tutorialsDB