### PR TITLE
fix(encore): remove DB resource fallback expression in buildSnapshot;…

### DIFF
--- a/backend/tutorials/versioning.ts
+++ b/backend/tutorials/versioning.ts
@@ -90,13 +90,12 @@ export const restoreVersion = api<{ tutorialId: number; version: number }, { res
   }
 );
 
-async function buildSnapshot(tutorialId: number, db?: any): Promise<any> {
-  const database = db ?? tutorialsDB;
-  const tutorial = await database.queryRow<any>`
+async function buildSnapshot(tutorialId: number, db: any): Promise<any> {
+  const tutorial = await db.queryRow<any>`
     SELECT id, title, description, model, provider, difficulty, tags, model_maker_id, created_at, updated_at
     FROM tutorials WHERE id = ${tutorialId}
   `;
-  const steps = await database.queryAll<any>`
+  const steps = await db.queryAll<any>`
     SELECT step_order, title, content, code_template, expected_output, model_params
     FROM tutorial_steps WHERE tutorial_id = ${tutorialId}
     ORDER BY step_order


### PR DESCRIPTION
… require explicit db param (#8)

## Summary by Sourcery

Enforce explicit database parameter in buildSnapshot by removing the fallback to the global DB resource and updating its signature and internal queries accordingly.

Enhancements:
- Change buildSnapshot signature to require an explicit db argument instead of optional
- Remove fallback assignment to the global tutorialsDB in buildSnapshot
- Directly use the passed db parameter for querying tutorial and steps data