### PR TITLE
fix(encore): avoid optional OPENAI_* secrets for Poe-only deploys

### DIFF
--- a/backend/execution/teacher.ts
+++ b/backend/execution/teacher.ts
@@ -3,8 +3,6 @@ import { secret } from "encore.dev/config";
 import { mapModelForProvider } from "./providers/aliases";
 
 const poeApiKey = secret("POE_API_KEY");
-const openaiBaseUrl = secret("OPENAI_BASE_URL");
-const openaiApiKey = secret("OPENAI_API_KEY");
 
 interface TeacherRequest {
   model: "GPT-OSS-20B" | "GPT-OSS-120B";
@@ -165,8 +163,9 @@ export const teacherGenerate = api<TeacherRequest, TeacherResponse>(
         }
         return { success: true, content };
       } else {
-        const baseUrl = openaiBaseUrl();
-        const apiKey = openaiApiKey();
+        // Read from env to avoid declaring optional Encore secrets when not used
+        const baseUrl = process.env.OPENAI_BASE_URL;
+        const apiKey = process.env.OPENAI_API_KEY;
         if (!baseUrl || !apiKey) {
           throw APIError.failedPrecondition("OPENAI_BASE_URL and OPENAI_API_KEY required for openai-compatible provider");
         }


### PR DESCRIPTION
Move OPENAI_* access out of Encore secrets and into env reads scoped to the openai-compatible branch in teacher service. Prevents Encore app compile error when deploying with only Poe configured.