### PR TITLE
web: fix Tailwind base import for Next/Vercel

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,4 +1,5 @@
-@import "tailwindcss/preflight";
+@tailwind base;
+@tailwind components;
 @tailwind utilities;
 
 /* Web fonts: League Spartan (Google Fonts) */


### PR DESCRIPTION
Replace deprecated @import 'tailwindcss/preflight' with @tailwind base; components; utilities. Fixes Vercel build error Can't resolve 'tailwindcss/preflight'.

## Summary by Sourcery

Bug Fixes:
- Replace @import 'tailwindcss/preflight' with @tailwind base, components, and utilities to resolve Vercel build error