### PR TITLE
web: middleware hardening to prevent 500s (Clerk wrapper + public routes)

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,25 +1,34 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { clerkMiddleware } from "@clerk/nextjs/server";
 
 // Fall back to a no-op middleware if Clerk keys are not configured
 const hasClerk = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY && !!process.env.CLERK_SECRET_KEY;
 
-export default hasClerk
-  ? clerkMiddleware({
-      // Mark common public routes to avoid unnecessary auth work
+// Robust wrapper to avoid 500s on misconfiguration
+export default function middleware(req: NextRequest) {
+  if (process.env.DISABLE_CLERK_MIDDLEWARE === '1') return NextResponse.next();
+  if (!hasClerk) return NextResponse.next();
+  try {
+    const handler = clerkMiddleware({
+      // Keep common pages public; API handlers enforce auth explicitly
       publicRoutes: [
         "/",
         "/stream",
-        "/tutorials",
-        "/tutorial/:id",
-        "/api/setup", // GET probe is public; POST is guarded in handler
+        "/tutorials(.*)",
+        "/frontend(.*)",
+        "/api/setup",
       ],
-    })
-  : (() => NextResponse.next());
+    }) as unknown as (req: NextRequest) => Response | Promise<Response>;
+    return handler(req);
+  } catch {
+    // Never take down the site from middleware
+    return NextResponse.next();
+  }
+}
 
 export const config = {
   matcher: [
-    // Recommended Clerk pattern: run on all paths except static/_next; also include root
+    // Run on all paths except static assets and _next
     "/((?!.*\\..*|_next).*)",
     "/",
     "/(api|trpc)(.*)",


### PR DESCRIPTION
Wrap Clerk middleware, add DISABLE_CLERK_MIDDLEWARE escape hatch, and broaden publicRoutes. Prevents MIDDLEWARE_INVOCATION_FAILED from taking down the site while API routes remain auth-guarded.

## Summary by Sourcery

Harden the Clerk middleware integration to prevent site-wide errors, add a way to disable the middleware via environment variable, and expand unauthenticated public routes.

Bug Fixes:
- Catch errors in the Clerk middleware to avoid 500 responses and fall back gracefully.

Enhancements:
- Add a DISABLE_CLERK_MIDDLEWARE escape hatch to skip Clerk processing.
- Consolidate Clerk middleware usage into a wrapper that checks configuration and handles failures.
- Expand publicRoutes patterns to include tutorial and frontend paths without authentication.
- Refine the middleware matcher to run on dynamic routes except static assets and Next.js internals.