### PR TITLE
web: no-op middleware hotfix

### DIFF
--- a/web/middleware.ts
+++ b/web/middleware.ts
@@ -1,29 +1,9 @@
 import { NextResponse, type NextRequest } from "next/server";
-import { clerkMiddleware } from "@clerk/nextjs/server";
 
-// Fall back to a no-op middleware if Clerk keys are not configured
-const hasClerk = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY && !!process.env.CLERK_SECRET_KEY;
-
-// Robust wrapper to avoid 500s on misconfiguration
-export default function middleware(req: NextRequest) {
-  if (process.env.DISABLE_CLERK_MIDDLEWARE === '1') return NextResponse.next();
-  if (!hasClerk) return NextResponse.next();
-  try {
-    const handler = clerkMiddleware({
-      // Keep common pages public; API handlers enforce auth explicitly
-      publicRoutes: [
-        "/",
-        "/stream",
-        "/tutorials(.*)",
-        "/frontend(.*)",
-        "/api/setup",
-      ],
-    }) as unknown as (req: NextRequest) => Response | Promise<Response>;
-    return handler(req);
-  } catch {
-    // Never take down the site from middleware
-    return NextResponse.next();
-  }
+// Temporarily disable Clerk middleware to unblock deploys.
+// API routes still perform auth checks in their handlers using safeAuth().
+export default function middleware(_req: NextRequest) {
+  return NextResponse.next();
 }
 
 export const config = {


### PR DESCRIPTION
Remove Clerk middleware usage on main (no publicRoutes option) to fix type error and prevent runtime 500s; API routes continue to enforce auth in handlers with safeAuth/demo bypass.

## Summary by Sourcery

Temporarily disable Clerk middleware in Next.js middleware to prevent type errors and runtime 500s by falling back to a no-op handler, while preserving authentication enforcement in API routes.

Bug Fixes:
- Remove Clerk middleware usage in middleware.ts to fix type errors and avoid runtime 500s.

Enhancements:
- Retain auth checks in API route handlers via safeAuth/demo bypass.