### PR TITLE
From‑Text generation + demo polish

### DIFF
--- a/backend/export/notebook.ts
+++ b/backend/export/notebook.ts
@@ -91,6 +91,39 @@ export function buildNotebook(
   ];
   cells.push({ cell_type: "code", metadata: {}, source: envSource, outputs: [], execution_count: null });
 
+  // 3b) Pre-flight connection check
+  cells.push({
+    cell_type: "code",
+    metadata: {},
+    source: [
+      "# Pre-flight check: verify API connectivity\n",
+      "from openai import OpenAI\n",
+      "import os, sys\n",
+      "base = os.environ.get('OPENAI_BASE_URL')\n",
+      "key = os.environ.get('OPENAI_API_KEY')\n",
+      "if not base or not key:\n",
+      "    print('❌ Missing OPENAI_BASE_URL or OPENAI_API_KEY. Set them above.')\n",
+      "else:\n",
+      "    try:\n",
+      "        client = OpenAI(base_url=base, api_key=key)\n",
+      "        # lightweight call: list models or small completion\n",
+      "        ok = False\n",
+      "        try:\n",
+      "            _ = client.models.list()\n",
+      "            ok = True\n",
+      "        except Exception:\n",
+      "            # Fallback to a 1-token chat call\n",
+      "            _ = client.chat.completions.create(model=\"${meta.model}\", messages=[{\"role\":\"user\",\"content\":\"ping\"}], max_tokens=1)\n",
+      "            ok = True\n",
+      "        if ok:\n",
+      "            print('✅ API key is working and connected to provider.')\n",
+      "    except Exception as e:\n",
+      "        print('❌ Connection failed. Please check your API key and base URL.\\n', e)\n",
+    ],
+    outputs: [],
+    execution_count: null,
+  });
+
   // 4) Quick smoke test
   cells.push({
     cell_type: "code",

--- a/web/app/api/generate-from-text/route.ts
+++ b/web/app/api/generate-from-text/route.ts
@@ -1,0 +1,64 @@
+import { safeAuth, demoBypassEnabled } from "../../../lib/auth";
+import { backendUrl } from "../../../lib/backend";
+
+export async function POST(req: Request) {
+  const { userId, getToken } = await safeAuth();
+  if (!userId && !demoBypassEnabled()) return new Response("Unauthorized", { status: 401 });
+  const body = await req.json().catch(() => null);
+  if (!body?.textContent) return new Response("textContent required", { status: 400 });
+
+  const teacherModel = body.teacherModel || "GPT-OSS-20B";
+  const difficulty = body.difficulty || "beginner";
+  const includeAssessment = Boolean(body.includeAssessment);
+  const provider = (body.provider || process.env.TEACHER_PROVIDER || 'poe') as 'poe' | 'openai-compatible';
+  const includeReasoning = Boolean(body.showReasoning);
+  const token = await getToken();
+
+  // 1) Generate lesson structure from pasted text
+  const genCtrl = new AbortController();
+  const genTimer = setTimeout(() => genCtrl.abort(), 60_000);
+  const genResp = await fetch(backendUrl('/lessons/generate-from-text'), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ textContent: body.textContent, difficulty, teacherModel, includeAssessment, provider, includeReasoning }),
+    signal: genCtrl.signal,
+  });
+  const gen = await genResp.json();
+  clearTimeout(genTimer);
+  if (!gen.success) return Response.json(gen, { status: 200 });
+
+  const lesson = gen.lesson;
+  // Optional overrides from UI (provider/model picker)
+  if (body.targetProvider && typeof body.targetProvider === 'string') {
+    lesson.provider = body.targetProvider;
+  }
+  if (body.targetModel && typeof body.targetModel === 'string' && body.targetModel.trim()) {
+    lesson.model = body.targetModel.trim();
+  }
+
+  // 2) Persist lesson into tutorials
+  const impCtrl = new AbortController();
+  const impTimer = setTimeout(() => impCtrl.abort(), 60_000);
+  const impResp = await fetch(backendUrl('/tutorials/import'), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+    body: JSON.stringify(lesson),
+    signal: impCtrl.signal,
+  });
+  clearTimeout(impTimer);
+  if (!impResp.ok) {
+    const t = await impResp.text();
+    return new Response(`Import failed: ${t}`, { status: 500 });
+  }
+  const imp = await impResp.json();
+
+  const preview = {
+    title: lesson.title,
+    description: lesson.description,
+    learning_objectives: lesson.learning_objectives || [],
+    first_step: lesson.steps?.[0] || null,
+    model_maker: lesson.model_maker || null,
+  };
+
+  return Response.json({ success: true, tutorialId: imp.tutorialId, meta: { repaired: !!gen?.meta?.repaired, reasoning_summary: gen?.meta?.reasoning_summary }, preview });
+}

--- a/web/app/api/hf/model/route.ts
+++ b/web/app/api/hf/model/route.ts
@@ -1,5 +1,9 @@
 export const runtime = 'nodejs';
 
+// Simple in-memory cache with TTL to reduce HF calls
+const cache = new Map<string, { data: any; ts: number }>();
+const TTL_MS = 5 * 60_000; // 5 minutes
+
 export async function GET(req: Request) {
   // Check offline mode via backend probe routed through web API
   try {
@@ -18,6 +22,13 @@ export async function GET(req: Request) {
   }
 
   const apiUrl = 'https://huggingface.co/api/models/' + encodeURIComponent(repo);
+
+  // Serve from cache if fresh
+  const now = Date.now();
+  const c = cache.get(repo);
+  if (c && now - c.ts < TTL_MS) {
+    return Response.json(c.data, { status: 200 });
+  }
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), 1000);
   try {
@@ -26,15 +37,20 @@ export async function GET(req: Request) {
       signal: ac.signal,
     });
     clearTimeout(timer);
-    if (!resp.ok) return Response.json({ license: null, tags: [], downloads: null }, { status: 200 });
+    if (!resp.ok) {
+      console.error(`[hf/model] HF responded ${resp.status} for ${repo}`);
+      return Response.json({ license: null, tags: [], downloads: null }, { status: 200 });
+    }
     const data = await resp.json().catch(() => ({} as any));
     const license = (data as any)?.license || null;
     const tags = Array.isArray((data as any)?.tags) ? (data as any).tags.slice(0, 20) : [];
     const downloads = (data as any)?.downloads || null;
-    return Response.json({ license, tags, downloads }, { status: 200 });
+    const payload = { license, tags, downloads };
+    cache.set(repo, { data: payload, ts: now });
+    return Response.json(payload, { status: 200 });
   } catch {
     clearTimeout(timer);
+    console.error(`[hf/model] Timeout or fetch error for ${repo}`);
     return Response.json({ license: null, tags: [], downloads: null }, { status: 200 });
   }
 }
-

--- a/web/components/LocalRuntimeStatus.tsx
+++ b/web/components/LocalRuntimeStatus.tsx
@@ -1,0 +1,35 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function LocalRuntimeStatus() {
+  const [detected, setDetected] = useState<null | boolean>(null);
+  const [label, setLabel] = useState<string>("Detecting…");
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const resp = await fetch('/api/setup', { cache: 'no-store' });
+        const data = await resp.json();
+        if (!alive) return;
+        const models = Array.isArray(data?.availableModels) ? data.availableModels : [];
+        setDetected(models.length > 0);
+        if (models.length > 0) setLabel('Local runtime detected'); else setLabel('Local runtime not found');
+      } catch {
+        if (!alive) return;
+        setDetected(false);
+        setLabel('Local runtime not found');
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  if (detected === null) return null;
+
+  return (
+    <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-medium border select-none ${detected ? 'bg-green-100 text-green-800 border-green-200' : 'bg-yellow-100 text-yellow-800 border-yellow-200'}`}>
+      {label}
+    </span>
+  );
+}
+

--- a/web/components/LocalSetupHelper.tsx
+++ b/web/components/LocalSetupHelper.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Button } from "./Button";
+
+export default function LocalSetupHelper({ visible = true }: { visible?: boolean }) {
+  const [checking, setChecking] = useState(false);
+  const [status, setStatus] = useState<null | { ok: boolean; models: string[] }>(null);
+
+  if (!visible) return null;
+
+  async function testConnection() {
+    setChecking(true);
+    setStatus(null);
+    try {
+      const resp = await fetch('/api/providers/models', { cache: 'no-store' });
+      if (!resp.ok) throw new Error('Request failed');
+      const data = await resp.json();
+      const models = Array.isArray(data?.models) ? data.models : [];
+      setStatus({ ok: models.length > 0, models });
+    } catch {
+      setStatus({ ok: false, models: [] });
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <div className="mt-2 border border-gray-800 rounded p-3 bg-gray-950/40 text-sm text-gray-200">
+      <div className="font-medium mb-1">Local Setup Helper</div>
+      <div className="text-gray-300">To run the teacher locally, install Ollama or use LM Studio.</div>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        <code className="px-2 py-1 rounded bg-gray-900 border border-gray-800 text-xs">ollama pull gpt-oss:20b</code>
+        <Button variant="secondary" onClick={() => navigator.clipboard.writeText('ollama pull gpt-oss:20b')}>Copy</Button>
+        <Button variant="secondary" onClick={testConnection} disabled={checking}>{checking ? 'Testing…' : 'Test Connection'}</Button>
+        {status && (
+          status.ok ? (
+            <span className="inline-flex items-center text-xs px-2 py-1 rounded bg-green-900/30 text-green-200 border border-green-800">Ready to generate! ({status.models.length} models detected)</span>
+          ) : (
+            <span className="inline-flex items-center text-xs px-2 py-1 rounded bg-yellow-900/30 text-yellow-200 border border-yellow-800">Not detected. Open Settings → Offline.</span>
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/web/components/NavBar.tsx
+++ b/web/components/NavBar.tsx
@@ -6,6 +6,7 @@ import MobileNav from "./MobileNav";
 
 export default function NavBar() {
   const OfflineBadge = dynamic(() => import("./OfflineBadge"), { ssr: false });
+  const LocalRuntimeStatus = dynamic(() => import("./LocalRuntimeStatus"), { ssr: false });
   return (
     <nav className="bg-paper-0 border-b border-ink-100 text-ink-900">
       <div className="mx-auto max-w-7xl px-6 md:px-8 h-16 flex items-center justify-between">
@@ -22,6 +23,7 @@ export default function NavBar() {
         </div>
         <div className="hidden md:flex items-center gap-3">
           <OfflineBadge />
+          <LocalRuntimeStatus />
           <Link href="/generate" className="inline-flex items-center h-10 px-4 rounded-[12px] bg-alain-yellow text-alain-blue font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue">Get Started</Link>
         </div>
         <div className="md:hidden">
@@ -31,4 +33,3 @@ export default function NavBar() {
     </nav>
   );
 }
-

--- a/web/components/PreviewPanel.tsx
+++ b/web/components/PreviewPanel.tsx
@@ -60,8 +60,27 @@ export function PreviewPanel({ tutorialId, preview, repaired, onExport }: Props)
             await onExport(suggested);
           }}
         >Export Notebook</Button>
+        <Button
+          variant="secondary"
+          onClick={async () => {
+            try {
+              const res = await fetch((process.env.NEXT_PUBLIC_BACKEND_BASE || 'http://localhost:4000') + `/tutorials/${tutorialId}`);
+              const lesson = await res.json();
+              const blob = new Blob([JSON.stringify(lesson, null, 2)], { type: 'application/json' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `${(preview.title || 'lesson').replace(/\s+/g,'_')}.json`;
+              document.body.appendChild(a);
+              a.click();
+              a.remove();
+              URL.revokeObjectURL(url);
+            } catch {
+              // noop
+            }
+          }}
+        >Download JSON</Button>
       </div>
     </div>
   );
 }
-


### PR DESCRIPTION
This PR adds several high‑impact tweaks to improve demo UX and local onboarding.\n\nHighlights\n- From‑Text lesson generation (Encore: /lessons/generate-from-text) with validation+repair and tiny retry\n- Web proxy /api/generate-from-text\n- HF model metadata caching (5m TTL) with server‑side logging\n- Local Setup Helper: copy `ollama pull gpt-oss:20b`, Test Connection\n- Navbar provider chip: "Local runtime detected" vs "not found"\n- Preview: Download JSON button\n- Colab export: Pre‑flight check cell for API connectivity\n- Generate page: hide Show Reasoning (beta) (backend remains opt‑in)\n\nTouched files\n- backend/execution/lesson-generator.ts\n- backend/export/notebook.ts\n- web/app/api/generate-from-text/route.ts\n- web/app/api/hf/model/route.ts\n- web/app/generate/page.tsx\n- web/components/{LocalSetupHelper,LocalRuntimeStatus,NavBar,PreviewPanel}.tsx\n\nNotes\n- No change to default reasoning behavior (opt‑in only).\n- Caching in HF route is in‑memory with a 5‑minute TTL.