### PR TITLE
Fix Encore path param for /lmstudio/options/:id

### DIFF
--- a/backend/execution/lmstudio_repo.ts
+++ b/backend/execution/lmstudio_repo.ts
@@ -7,9 +7,9 @@ export const lmstudioSearch = api<{}, { message: string }>(
   async () => ({ message: "LM Studio search disabled in backend; use web/app/api/lmstudio/search" })
 );
 
-export const lmstudioOptions = api<{}, { message: string }>(
+export const lmstudioOptions = api<{ id: string }, { message: string }>(
   { expose: true, method: "GET", path: "/lmstudio/options/:id" },
-  async () => ({ message: "LM Studio options disabled in backend; use web/app/api/lmstudio/options/[id]" })
+  async ({ id }) => ({ message: "LM Studio options disabled in backend; use web/app/api/lmstudio/options/[id]" })
 );
 
 export const lmstudioDownload = api<{}, { message: string }>(


### PR DESCRIPTION
Encore build failed due to a schema mismatch: path had :id but request schema was {}.\n\nThis updates backend/execution/lmstudio_repo.ts to declare the request param { id: string } and accept it in the handler (unused, route remains disabled).\n\nShould unblock Encore build.

## Summary by Sourcery

Bug Fixes:
- Declare and accept the id path parameter in the lmstudioOptions API signature to resolve the schema mismatch