### PR TITLE
Follow-ups: runtime pin, monaco shim, Preview download, lmstudio param doc

### DIFF
--- a/backend/execution/lmstudio_repo.ts
+++ b/backend/execution/lmstudio_repo.ts
@@ -9,7 +9,8 @@ export const lmstudioSearch = api<{}, { message: string }>(
 
 export const lmstudioOptions = api<{ id: string }, { message: string }>(
   { expose: true, method: "GET", path: "/lmstudio/options/:id" },
-  async ({ id }) => ({ message: "LM Studio options disabled in backend; use web/app/api/lmstudio/options/[id]" })
+  // Note: _id is intentionally unused. Declared to satisfy Encore's path param schema; route remains disabled.
+  async ({ id: _id }) => ({ message: "LM Studio options disabled in backend; use web/app/api/lmstudio/options/[id]" })
 );
 
 export const lmstudioDownload = api<{}, { message: string }>(

--- a/web/app/api/generate-from-text/route.ts
+++ b/web/app/api/generate-from-text/route.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { safeAuth, demoBypassEnabled } from "../../../lib/auth";
 import { backendUrl } from "../../../lib/backend";
 

--- a/web/components/PreviewPanel.tsx
+++ b/web/components/PreviewPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Button } from "./Button";
+import { backendUrl } from "../lib/backend";
 
 type ModelMaker = { name: string; org_type: string; homepage?: string|null; license?: string|null; repo?: string|null };
 type Preview = { title: string; description: string; learning_objectives: string[]; first_step?: { title: string; content: string } | null; model_maker?: ModelMaker | null };
@@ -64,7 +65,7 @@ export function PreviewPanel({ tutorialId, preview, repaired, onExport }: Props)
           variant="secondary"
           onClick={async () => {
             try {
-              const res = await fetch((process.env.NEXT_PUBLIC_BACKEND_BASE || 'http://localhost:4000') + `/tutorials/${tutorialId}`);
+              const res = await fetch(backendUrl(`/tutorials/${tutorialId}`));
               const lesson = await res.json();
               const blob = new Blob([JSON.stringify(lesson, null, 2)], { type: 'application/json' });
               const url = URL.createObjectURL(blob);

--- a/web/types/monaco.d.ts
+++ b/web/types/monaco.d.ts
@@ -1,0 +1,2 @@
+declare module 'monaco-editor';
+


### PR DESCRIPTION
Small polish PR addressing review and DX:\n\n- export const runtime = 'nodejs' for web /api/generate-from-text to align with server APIs.\n- Add web/types/monaco.d.ts shim to silence local tsc when monaco types aren’t resolved.\n- PreviewPanel: use backendUrl(...) for Download JSON to avoid CORS surprises.\n- backend lmstudio options route: prefix unused id as _id and add a clarifying comment (declared only to satisfy Encore schema; route disabled).

## Summary by Sourcery

Polish developer experience and align runtime behaviors by exporting a consistent runtime, adding missing types, improving download links, and clarifying a disabled backend route.

Enhancements:
- Export runtime as 'nodejs' in the generate-from-text API to match other server endpoints
- Add a monaco-editor type declaration shim to silence local TypeScript errors
- Use the backendUrl helper in PreviewPanel for JSON downloads to avoid CORS issues
- Prefix the lmstudioOptions route parameter as _id and document its unused status to satisfy the schema while keeping the route disabled