### PR TITLE
Tests + Docs: provider fallbacks, From‑Text flow, pre‑flight

### DIFF
--- a/HACKATHON_README.md
+++ b/HACKATHON_README.md
@@ -33,11 +33,13 @@ Tagline: Learn models by doing.
 - Public Directory: Link in the header to explore tutorials with search and filters.
 - React SPA: Lightweight demo of the tutorial player.
 - Execution API (Encore.ts): Unified SSE endpoint for streaming completions.
+ - From Text generation: Paste any text (docs/article) to generate a runnable lesson (no HF metadata required).
 
 Notebook export (Colab)
 - Exported notebooks now include:
   - Provider setup cells (install OpenAI SDK, set OPENAI_BASE_URL/API_KEY; Poe defaults to https://api.poe.com/v1)
   - Secure auth cell for Colab: reads secrets from Colab `userdata` when available and falls back to a hidden `getpass()` prompt
+  - A Pre‑flight connection check cell that validates API connectivity before heavier steps
   - A quick smoke test cell to verify keys work with the selected model
   - Each lesson step rendered as markdown + a runnable code cell that sends the step prompt to the model
   - MCQ assessment cells with inline graders, plus an interactive ipywidgets variant (radio buttons + submit + feedback)
@@ -61,6 +63,7 @@ UI improvements (magical MVP)
 - Instant preview: after generation, preview title, description, objectives, and first step with one-click “Open Tutorial” or “Export Notebook”.
 - Transparent execution: “Show Request” reveals the JSON payload; copy as curl or OpenAI SDK is one click away.
 - Adapt Experience (beta): On tutorial pages, tailor content for Beginner/Intermediate/Advanced. Original content remains unchanged.
+ - Local Setup Helper: Under the Local model picker, copy `ollama pull gpt‑oss:20b` and click “Test Connection” to verify local models.
 
 Quick start
 1) Install: `npm install`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Option B — Strict Offline (Ollama)
 3) Open http://localhost:3000
 4) Paste `openai/gpt-oss-20b` → Provider: Local (OpenAI‑compatible) → Generate.
 5) Click "Download Colab Notebook" (works offline; no third-party calls in export).
+6) Note: Exported notebook includes a Pre‑flight cell that verifies API connectivity before running steps.
 Note: For local demos, you may set `DEMO_ALLOW_UNAUTH=1` to bypass auth.
 
 Option C — Local (LM Studio)
@@ -37,9 +38,18 @@ Option C — Local (LM Studio)
 3) Open http://localhost:3000
 4) In Generate: select “From Local Runtime” (auto-selected if detected), pick a model (e.g., `llama-3-8b-instruct`) and click Generate
 5) Run a step, then click “Download Colab Notebook”
+6) Note: The “Local Setup Helper” appears under the Local model picker with a copyable `ollama pull gpt-oss:20b` command and a Test Connection button.
 Notes:
 - Streaming is handled via the Next.js API route using SSE; Encore streaming is disabled in this MVP.
 - For local demos, you may set `DEMO_ALLOW_UNAUTH=1` to bypass auth.
+
+Option D — From Text (Docs → Lesson)
+1) On the Generate page, click “From Text”.
+2) Paste a snippet (e.g., a section from OpenAI docs on Harmony‑style prompting).
+3) Choose Teacher Provider (Poe or Local), then Generate → Preview → Export.
+Notes:
+- This bypasses Hugging Face metadata entirely; great for live copy‑paste demos.
+- Exported notebooks include the Pre‑flight check cell.
 
 Minimal offline cURL (no web UI)
 - Enable local demo bypass in backend env: `DEMO_ALLOW_UNAUTH=1`


### PR DESCRIPTION
Adds backend tests and docs polish.\n\nTests\n- backend/execution/models.test.ts: LM Studio fallback when Ollama down; unknown when no providers respond.\n- backend/execution/lesson-generator.test.ts: happy path for generateFromText (minimal JSON lesson).\n\nDocs\n- README.md: adds From Text demo path, Local Setup Helper note, and Colab Pre‑flight cell.\n- HACKATHON_README.md: TL;DR mentions From Text, Pre‑flight cell, and Local Setup Helper.

## Summary by Sourcery

Add backend tests for provider fallback and generateFromText, and update documentation with From Text flow, pre-flight checks, and Local Setup Helper instructions

Documentation:
- Document From Text demo flow in README and HACKATHON_README
- Add Pre-flight connectivity check note in exported notebooks
- Add Local Setup Helper instructions under the local model picker

Tests:
- Add tests for provider fallback to LM Studio and unknown provider in listProviderModels
- Add happy path test for generateFromText producing a minimal JSON lesson