### PR TITLE
UI: Copy cURL in tutorial player toolbar

### DIFF
--- a/HACKATHON_README.md
+++ b/HACKATHON_README.md
@@ -62,6 +62,7 @@ UI improvements (magical MVP)
 - Fix-it actions: on validation errors, click “Auto-fix and Import” to repair missing fields/steps.
 - Instant preview: after generation, preview title, description, objectives, and first step with one-click “Open Tutorial” or “Export Notebook”.
 - Transparent execution: “Show Request” reveals the JSON payload; copy as curl or OpenAI SDK is one click away.
+- New: A “Copy cURL” button sits next to “Show Request” in the player toolbar for instant sharing.
 - Adapt Experience (beta): On tutorial pages, tailor content for Beginner/Intermediate/Advanced. Original content remains unchanged.
  - Local Setup Helper: Under the Local model picker, copy `ollama pull gpt‑oss:20b` and click “Test Connection” to verify local models.
 

--- a/web/app/tutorial/[id]/page.tsx
+++ b/web/app/tutorial/[id]/page.tsx
@@ -521,6 +521,20 @@ export default function TutorialPage({ params }: { params: { id: string } }) {
             >
               {showRequest ? 'Hide Request' : 'Show Request'}
             </Button>
+            <Button
+              className="text-xs px-2 py-1"
+              title="Copy the last request as a curl command"
+              onClick={() => {
+                if (curl) {
+                  navigator.clipboard.writeText(curl);
+                  setToast('Copied cURL');
+                  setTimeout(() => setToast(null), 1000);
+                }
+              }}
+              variant="secondary"
+            >
+              Copy cURL
+            </Button>
             {executionState.status === 'completed' && (
               <span className="text-sm text-green-400 font-medium">✓ Completed</span>
             )}


### PR DESCRIPTION
Adds a small, demo-friendly polish:

- New "Copy cURL" button next to "Show Request" in the tutorial player.
- Uses the same request payload already constructed; no new deps.
- Shows a short toast on copy.
- Documentation updated in HACKATHON_README.md (UI improvements).

This is intentionally minimal and low risk — no behavior changes to execution or providers.

## Summary by Sourcery

Add a Copy cURL button to the tutorial player toolbar using the existing request payload, show a brief toast on copy, and update documentation accordingly.

New Features:
- Add 'Copy cURL' button to tutorial player toolbar to copy the latest request as a curl command

Enhancements:
- Display a temporary toast notification confirming cURL copy

Documentation:
- Document the new 'Copy cURL' button in HACKATHON_README.md