### PR TITLE
Quick fixes: GitHub issue link, repo canonical, inflight consistency

### DIFF
--- a/HACKATHON_README.md
+++ b/HACKATHON_README.md
@@ -241,7 +241,8 @@ Notes
 —
 
 ## Submission Details
-- Repo: https://gitlab.com/daniel-p-green/alain-ai-learning-platform
+- Repo: https://github.com/daniel-p-green/alain-ai-learning-platform
+- Mirror (historical): https://gitlab.com/daniel-p-green/alain-ai-learning-platform
 - Leap Project ID: <add here>
 - How to run: See “Run Locally” above and `alain-ai-learning-platform/README.md`.
 - Contact: hackathon@leap.new (per event instructions)

--- a/backend/execution/lesson-generator.ts
+++ b/backend/execution/lesson-generator.ts
@@ -213,14 +213,13 @@ export const generateLocalLesson = api<{
             return { success: false, error: { code: "validation_error", message: "Repaired lesson failed validation", details: v2.errors } } as any;
           }
         }
-        inflight.delete(key);
         return { success: true, lesson, meta: { repaired: usedRepair, reasoning_summary: reasoningSummary } } as any;
       } catch (error: any) {
-        inflight.delete(key);
         return { success: false, error: { code: 'generation_error', message: error?.message || 'Failed to generate' } } as any;
       }
     })();
     inflight.set(key, task);
+    task.finally(() => setTimeout(() => inflight.delete(key), 5000));
     return await task;
   }
 );

--- a/backend/utils/ratelimit.ts
+++ b/backend/utils/ratelimit.ts
@@ -13,7 +13,5 @@ export function allowRate(userId: string, key: string, max: number, windowMs: nu
     return { ok: false, retryAfter };
   }
   arr.push(now);
-  if (arr.length === 0) store.delete(k);
   return { ok: true };
 }
-

--- a/web/app/tutorial/[id]/page.tsx
+++ b/web/app/tutorial/[id]/page.tsx
@@ -311,9 +311,20 @@ export default function TutorialPage({ params }: { params: { id: string } }) {
     <div className="max-w-5xl mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
         <a className="text-brand-blue hover:underline" href="/tutorials">← Back</a>
-        <a className="text-xs text-gray-400 hover:underline" target="_blank" href={
-          `https://gitlab.com/daniel-p-green/alain-ai-learning-platform/-/issues/new?issue%5Btitle%5D=Tutorial%20Issue:%20${encodeURIComponent(String(tutorial?.title||''))}&issue%5Bdescription%5D=${encodeURIComponent(`tutorial_id=${tutorial?.id}\nstep=${step?.step_order}`)}`
-        }>Report issue</a>
+        {(() => {
+          const repo = process.env.NEXT_PUBLIC_GITHUB_REPO; // e.g., owner/name
+          const title = `Tutorial Issue: ${String(tutorial?.title || '')}`;
+          const body = `tutorial_id=${tutorial?.id}\nstep=${step?.step_order}`;
+          const ghUrl = repo ? `https://github.com/${repo}/issues/new?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}` : null;
+          return (
+            <a
+              className="text-xs text-gray-400 hover:underline"
+              target="_blank"
+              href={ghUrl || `https://github.com/new`}
+              rel="noopener noreferrer"
+            >Report issue</a>
+          );
+        })()}
       </div>
       <div className="flex items-center justify-between gap-3">
         <h1 className="text-3xl font-bold">{tutorial.title}</h1>


### PR DESCRIPTION
Small, low-risk fixes:\n\n- Tutorial toolbar: "Report issue" opens GitHub Issues for NEXT_PUBLIC_GITHUB_REPO with prefilled title/body.\n- HACKATHON_README: points to GitHub repo; notes GitLab mirror is historical.\n- Rate limiter: remove unreachable cleanup line.\n- Lesson generation: unify inflight cleanup behavior (5s delayed delete) for local/HF.\n\nNo dependency changes; targeted edits only.

## Summary by Sourcery

Apply small fixes to improve issue reporting, repository links, and cleanup logic

Enhancements:
- Use NEXT_PUBLIC_GITHUB_REPO to open GitHub Issues for the tutorial "Report issue" link with a fallback to github.com/new
- Update HACKATHON_README to point to the GitHub repo as canonical and annotate the GitLab mirror as historical
- Remove unreachable cleanup code in the rate limiter utility
- Unify lesson generation inflight cleanup by scheduling deletion after a 5-second delay