### PR TITLE
Brand assets + Concepts index + Tutorials hardening

### DIFF
--- a/web/app/concepts/page.tsx
+++ b/web/app/concepts/page.tsx
@@ -1,0 +1,37 @@
+export const metadata = {
+  title: "ALAIN — Concepts Index",
+  description: "Quick links to in-progress concepts and demos.",
+};
+
+const links: Array<{ href: string; title: string; desc: string }> = [
+  { href: "/blueprint", title: "Blueprint (Tokens)", desc: "Primary brand page using new ALAIN design tokens." },
+  { href: "/blueprint/agent", title: "Agent Variant", desc: "Gradient hero, bold agent-style landing." },
+  { href: "/blueprint/devtool", title: "Devtool Variant", desc: "Developer-focused hero with code emphasis." },
+  { href: "/blueprint/anthropic", title: "Anthropic Variant", desc: "Soft, academic landing concept." },
+  { href: "/brand-demo/landing", title: "Brand Demo Landing", desc: "WIP brand showcase landing." },
+  { href: "/generate", title: "Generate", desc: "HF / Local / From Text lesson generation." },
+  { href: "/tutorials", title: "Tutorials Directory", desc: "Browse, search, and filter tutorials." },
+  { href: "/phases", title: "ALAIN‑Kit Phases", desc: "Research / Design / Develop / Validate prompt runner." },
+  { href: "/lmstudio", title: "LM Studio Explorer", desc: "Local model explorer; shows banner if SDK missing." },
+  { href: "/settings", title: "Settings", desc: "Runtime presets and offline/hosted toggles." },
+  { href: "/health", title: "Health", desc: "Simple diagnostics and environment info." },
+];
+
+export default function ConceptsIndex() {
+  return (
+    <div className="mx-auto max-w-5xl px-6 md:px-8 py-10 space-y-6 text-ink-900">
+      <h1 className="font-display font-bold text-[36px] leading-[42px] tracking-tight">Concepts Index</h1>
+      <p className="font-inter text-ink-700">Explore branding variants and product flows independently.</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {links.map((l) => (
+          <a key={l.href} href={l.href} className="p-4 rounded-card bg-paper-0 border border-ink-100 shadow-card hover:shadow-cardHover transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue">
+            <div className="font-display font-semibold text-[18px] leading-[24px]">{l.title}</div>
+            <div className="text-sm font-inter text-ink-700 mt-1">{l.desc}</div>
+            <div className="mt-3 text-alain-blue text-sm">{l.href}</div>
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/web/app/tutorials/page.tsx
+++ b/web/app/tutorials/page.tsx
@@ -144,7 +144,7 @@ export default function TutorialsPage() {
         <div className="flex items-center gap-3">
           {data && (
             <span className="text-sm text-ink-700">
-              {data.pagination.total} tutorials
+              {(data?.pagination?.total ?? data?.tutorials?.length ?? 0)} tutorials
             </span>
           )}
           <Button
@@ -205,7 +205,7 @@ export default function TutorialsPage() {
               className="w-full px-3 py-2 bg-paper-0 border border-ink-100 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue"
             >
               <option value="">All Levels</option>
-              {data?.filters.difficulties.map(difficulty => (
+              {data?.filters?.difficulties?.map(difficulty => (
                 <option key={difficulty} value={difficulty}>
                   {difficulty.charAt(0).toUpperCase() + difficulty.slice(1)}
                 </option>
@@ -222,7 +222,7 @@ export default function TutorialsPage() {
               className="w-full px-3 py-2 bg-paper-0 border border-ink-100 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue"
             >
               <option value="">All Providers</option>
-              {data?.filters.providers.map(provider => (
+              {data?.filters?.providers?.map(provider => (
                 <option key={provider} value={provider}>
                   {provider.charAt(0).toUpperCase() + provider.slice(1)}
                 </option>
@@ -239,7 +239,7 @@ export default function TutorialsPage() {
               className="w-full px-3 py-2 bg-paper-0 border border-ink-100 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue"
             >
               <option value="">All Creators</option>
-              {(data?.filters.modelMakers || []).map(m => (
+              {(data?.filters?.modelMakers || []).map(m => (
                 <option key={m} value={m}>{m}</option>
               ))}
             </select>
@@ -252,11 +252,11 @@ export default function TutorialsPage() {
         </div>
 
         {/* Tags */}
-        {data?.filters.tags && data.filters.tags.length > 0 && (
+        {data?.filters?.tags && data.filters.tags.length > 0 && (
           <div>
             <label className="block text-sm font-medium mb-2 text-ink-900">Tags</label>
             <div className="flex flex-wrap gap-2">
-              {data.filters.tags.slice(0, 10).map(tag => (
+              {data.filters.tags.slice(0, 10)?.map(tag => (
                 <Button
                   key={tag}
                   onClick={() => handleTagToggle(tag)}
@@ -273,7 +273,7 @@ export default function TutorialsPage() {
 
       {/* Tutorial Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {data?.tutorials.map((tutorial) => (
+        {data?.tutorials?.map((tutorial) => (
           <div key={tutorial.id} className="border border-ink-100 rounded-card p-4 bg-paper-0 shadow-card hover:shadow-cardHover transition-shadow">
             <div className="flex items-start justify-between mb-2">
               <h2 className="font-display font-semibold text-[20px] leading-[28px]">{tutorial.title}</h2>
@@ -329,7 +329,7 @@ export default function TutorialsPage() {
       </div>
 
       {/* Pagination */}
-      {data?.pagination && data.pagination.totalPages > 1 && (
+      {data?.pagination && (data.pagination.totalPages > 1) && (
         <div className="flex items-center justify-center gap-2">
           <Button onClick={() => loadTutorials(data.pagination.page - 1)} disabled={!data.pagination.hasPrev} variant="secondary" className="px-3 py-1 text-sm">Previous</Button>
 
@@ -342,7 +342,7 @@ export default function TutorialsPage() {
       )}
 
       {/* Empty State */}
-      {data?.tutorials.length === 0 && (
+      {data?.tutorials?.length === 0 && (
         <div className="text-center py-12">
           <div className="text-ink-700 mb-4">📚</div>
           <h3 className="font-display font-semibold text-[24px] leading-[30px] mb-2">No tutorials found</h3>

--- a/web/public/brand/alain-monogram.svg
+++ b/web/public/brand/alain-monogram.svg
@@ -1,15 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" role="img" aria-label="ALAIN monogram">
-  <style>
-    :root { --yolk:#FFD22E; --ink:#1B1B1B; --red:#C33228; --blue:#2CA6A4; }
-  </style>
-  <!-- shadow -->
-  <rect x="28" y="64" width="200" height="128" rx="64" ry="64" fill="var(--ink)" opacity="0.35"/>
-  <!-- lozenge -->
-  <rect x="24" y="56" width="200" height="128" rx="64" ry="64" fill="var(--yolk)" stroke="var(--ink)" stroke-width="8"/>
-  <!-- A -->
-  <text x="124" y="150" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif" font-size="110" font-style="italic" fill="var(--red)" stroke="var(--ink)" stroke-width="5" paint-order="stroke fill">A</text>
-  <!-- blue caret -->
-  <path d="M162 84 l9 -14 l9 14 z" fill="var(--blue)"/>
+  <!-- Simple ellipse monogram matching ALAIN brand colors -->
+  <ellipse cx="128" cy="128" rx="110" ry="48" fill="#FFDA1A" stroke="#004580" stroke-width="8"/>
+  <!-- Stylized A mark -->
+  <path d="M98 155 L128 85 L158 155 L144 155 L136 137 L120 137 L112 155 Z" fill="#0058A3"/>
 </svg>
-

--- a/web/public/brand/alain-wordmark.svg
+++ b/web/public/brand/alain-wordmark.svg
@@ -1,12 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="260" viewBox="0 0 960 260" role="img" aria-label="ALAIN wordmark">
-  <style>
-    :root { --red:#C33228; --ink:#1B1B1B; --blue:#2CA6A4; }
-  </style>
-  <rect width="100%" height="100%" fill="white"/>
-  <text x="60" y="185" font-family="Georgia, 'Times New Roman', serif" font-size="170" font-style="italic" fill="var(--ink)" opacity="0.35" dx="6" dy="6">Alain</text>
-  <text x="60" y="185" font-family="Georgia, 'Times New Roman', serif" font-size="170" font-style="italic" fill="var(--red)" stroke="var(--ink)" stroke-width="7" paint-order="stroke fill">Alain</text>
-  <!-- Accent caret -->
-  <path d="M515 92 l14 -22 l14 22 z" fill="var(--blue)"/>
+<svg width="1500" height="800" viewBox="0 0 1500 800" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="ALAIN wordmark">
+  <!-- ALAIN primary wordmark on white ellipse with blue letters, outline stroke -->
+  <ellipse cx="750" cy="400" rx="700" ry="300" fill="#FFFFFF" stroke="#004580" stroke-width="12"/>
+  <path d="M257.861 255H333.661L442.461 519H359.861L343.061 473.2H248.861L231.861 519H149.061L257.861 255ZM274.861 406H317.061L296.261 347.8H295.661L274.861 406ZM457.295 255H534.895V451.8H625.095V519H457.295V255ZM744.783 255H820.583L929.383 519H846.783L829.983 473.2H735.783L718.783 519H635.983L744.783 255ZM761.783 406H803.983L783.183 347.8H782.583L761.783 406ZM943.017 255H1020.42V519H943.017V255ZM1127.38 325.4L1133.18 326.4V519H1055.78V255H1160.38L1246.58 447L1240.78 448.2V255H1318.18V519H1212.98L1127.38 325.4Z" fill="#0058A3"/>
 </svg>
-


### PR DESCRIPTION
This PR updates the brand assets, adds a concepts index, and hardens the Tutorials page.\n\n- Brand: Replace web/public/brand/alain-*.svg with new logos from ALAIN-wordmarks.\n- Concepts: Add /concepts to quickly navigate branding variants and product flows.\n- Tutorials: Defensive checks for pagination/filters to prevent runtime errors when backend omits fields.\n\nNo dependency changes; purely web UI/content updates.