### PR TITLE
NavBar: single primary logo

### DIFF
--- a/web/components/NavBar.tsx
+++ b/web/components/NavBar.tsx
@@ -12,8 +12,8 @@ export default function NavBar() {
       <div className="mx-auto max-w-7xl px-6 md:px-8 h-16 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Link href="/" className="flex items-center gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue rounded">
-            <Image src="/brand/alain-monogram.svg" alt="ALAIN" width={28} height={28} priority />
-            <Image src="/brand/alain-wordmark.svg" alt="ALAIN wordmark" width={160} height={40} className="hidden sm:block" priority />
+            {/* Use a single primary logo everywhere (no separate monogram/wordmark) */}
+            <Image src="/brand/alain-wordmark.svg" alt="ALAIN" width={160} height={40} priority />
           </Link>
           <div className="hidden md:flex items-center gap-6 ml-6">
             <Link href="/tutorials" className="text-sm text-ink-700 hover:text-ink-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-alain-blue rounded">Tutorials</Link>


### PR DESCRIPTION
Simplifies branding in the header: use only the primary ALAIN logo in NavBar instead of separate monogram + wordmark. No other changes.

## Summary by Sourcery

Enhancements:
- Replace separate monogram and wordmark images with a single primary logo in the NavBar