### PR TITLE
chore(ui+docs): remove Poe EnvStatus from navbar; document KV lazy/op…

### DIFF
--- a/web/components/NavBar.tsx
+++ b/web/components/NavBar.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import BrandLogo from "./BrandLogo";
 import dynamic from "next/dynamic";
 import MobileNav from "./MobileNav";
-import EnvStatusBadge from "./EnvStatusBadge";
+// EnvStatusBadge (Poe status) removed from top nav for now
 import { useUser } from "@clerk/nextjs";
 import { SignedIn, SignedOut, SignInButton, SignUpButton, UserButton } from "@clerk/nextjs";
 
@@ -32,7 +32,6 @@ export default function NavBar() {
         <div className="hidden md:flex items-center gap-3">
           <OfflineBadge />
           <LocalRuntimeStatus />
-          <EnvStatusBadge />
           {/* Auth: show Sign In when signed out; avatar menu when signed in */}
           <SignedOut>
             <div className="flex items-center gap-2">

--- a/web/docs/OPERATIONS.md
+++ b/web/docs/OPERATIONS.md
@@ -32,3 +32,4 @@
 
 ## Caching
 - Optional Upstash KV caches listing and notebook JSON to reduce GitHub reads on cold starts.
+- KV is lazy-loaded and fully optional: if REDIS_URL/REDIS_TOKEN are not set, caching no-ops and the app builds without @upstash/redis installed.


### PR DESCRIPTION
…tional in OPERATIONS.md

## Summary by Sourcery

Remove EnvStatusBadge from navbar and document optional, lazy-loaded KV caching

Enhancements:
- Remove EnvStatusBadge component from the navigation bar

Documentation:
- Update OPERATIONS.md to state that Upstash KV caching is lazy-loaded and fully optional without REDIS_URL/REDIS_TOKEN