### PR TITLE
docs(readme): newcomer-focused rewrite + working badges and testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ Optional: Configure Upstash (KV) and GitHub export to open PRs for lessons.
 
 ---
 
+## Testing Instructions
+- No login required for core flow.
+- Web‑only fallback:
+  - Open https://alain-ruddy.vercel.app/generate
+  - Enable “Force fallback mode (no backend)”
+  - Paste model: https://huggingface.co/openai/gpt-oss-20b
+  - Click Generate → open tutorial → run a step → Export to Colab
+- Local quick check:
+  - `cd web && npm install && npm run dev`
+  - Visit http://localhost:3000/generate, enable fallback, repeat steps above
+- Optional offline (Ollama):
+  - `ollama pull gpt-oss:20b`
+  - In app, choose Local/OpenAI‑compatible and set model `gpt-oss:20b`
+
+---
+
 ## Devpost Write‑Up
 See `hackathon-notes/DEVPOST-Submission.md` for the full story, judging guidance, and screenshots.
 


### PR DESCRIPTION
Summary
- Rewrote README for newcomers: value prop, Try Now, minimal local setup, features, How It Works.
- Kept only working badges (MIT, Devpost hackathon, GPT-OSS-20B, Poe, Offline docs).
- Added Quick Links (demo, generate, dev guide, hackathon, Devpost write-up).
- Added Testing Instructions (web fallback, local dev, offline via Ollama).
- Added concise "Inspiration" and "Why GPT‑OSS‑20B" sections distilled from Devpost.
- Trimmed overly detailed sections; linked to docs and Devpost for depth.

Notes
- No code changes; docs only.
- Ready for review/merge.
