### PR TITLE
feat(web): HF model info normalization + UI hook-in (Generate)

### DIFF
--- a/web/__tests__/api-parse.test.ts
+++ b/web/__tests__/api-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { api, APIClientError } from '../lib/api';
+import { api, APIClientError, parseHfRef } from '../lib/api';
 
 function makeResponse(body: any, init?: { status?: number; json?: boolean }) {
   const status = init?.status ?? 200;
@@ -24,5 +24,17 @@ describe('api.parseGenerateResponse', () => {
   it('throws on unexpected format', async () => {
     const resp = makeResponse('not-json', { json: false, status: 500 });
     await expect(api.parseGenerateResponse(resp)).rejects.toBeInstanceOf(APIClientError);
+  });
+});
+
+describe('parseHfRef', () => {
+  it('parses owner/repo', () => {
+    expect(parseHfRef('meta-llama/Meta-Llama-3.1-8B-Instruct')).toEqual({ ok: true, repo: 'meta-llama/Meta-Llama-3.1-8B-Instruct' });
+  });
+  it('parses HF URL', () => {
+    expect(parseHfRef('https://huggingface.co/google/gemma-2-9b-it')).toEqual({ ok: true, repo: 'google/gemma-2-9b-it' });
+  });
+  it('rejects invalid', () => {
+    expect(parseHfRef('not a link')).toEqual({ ok: false });
   });
 });

--- a/web/__tests__/schemas.test.ts
+++ b/web/__tests__/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { GenerateSuccessSchema, ProvidersResponseSchema, ExportNotebookSchema } from '../lib/schemas';
+import { GenerateSuccessSchema, ProvidersResponseSchema, ExportNotebookSchema, HFModelInfoSchema } from '../lib/schemas';
 
 describe('schemas', () => {
   it('validates Generate success envelope', () => {
@@ -25,5 +25,10 @@ describe('schemas', () => {
     const r = ExportNotebookSchema.safeParse(sample);
     expect(r.success).toBe(true);
   });
-});
 
+  it('validates HF model info', () => {
+    const sample = { license: 'apache-2.0', tags: ['text-generation'], downloads: 12345 };
+    const r = HFModelInfoSchema.safeParse(sample);
+    expect(r.success).toBe(true);
+  });
+});

--- a/web/app/home/page.tsx
+++ b/web/app/home/page.tsx
@@ -1,39 +1,57 @@
 export const metadata = {
-  title: 'ALAIN — Home (Preview)',
-  description:
-    'Cleaner, focused home for ALAIN. Try Generate or browse Tutorials.',
+  title: 'ALAIN · Home',
+  description: 'Turn any model reference into a runnable lesson you can trust.',
 };
 
 export default function NewHomePage() {
+  const generateHref = '/generate';
   return (
-    <div className="mx-auto max-w-7xl px-6 md:px-8 py-12 space-y-12 text-ink-900">
-      <section className="space-y-4">
-        <p className="uppercase tracking-wide text-xs text-ink-700">ALAIN</p>
-        <h1 className="font-display font-bold text-[40px] leading-[44px] tracking-tight">Learn AI by doing — fast</h1>
-        <p className="font-inter text-[18px] leading-[28px] text-ink-700 max-w-3xl">
-          Paste a model reference and get a runnable, graded lab. Export to Colab, run locally or hosted, and inspect every request.
-        </p>
-        <div className="flex flex-wrap gap-3">
-          <a href={process.env.NEXT_PUBLIC_NEW_SHELL === '1' ? '/new/generate' : '/generate'} className="inline-flex items-center h-11 px-5 rounded-[12px] bg-alain-yellow text-alain-blue font-semibold">Get Started</a>
-          <a href="/tutorials" className="inline-flex items-center h-11 px-5 rounded-[12px] border border-ink-100 bg-paper-0 text-ink-900">Browse Tutorials</a>
+    <div className="mx-auto max-w-7xl px-6 md:px-8 py-16 space-y-16 text-ink-900">
+      {/* Hero */}
+      <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] items-center">
+        <div className="space-y-5">
+          <p className="uppercase tracking-wide text-xs text-ink-700">Applied Learning for AI</p>
+          <h1 className="font-display font-bold text-[40px] leading-[44px] tracking-tight">Learn faster with runnable notebooks</h1>
+          <p className="font-inter text-[18px] leading-[28px] text-ink-700 max-w-prose">
+            Paste a Hugging Face link or pick a local model. Generate a guided lesson with clear steps, quick checks, and an export to Colab or Jupyter.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <a href={generateHref} className="inline-flex items-center h-11 px-5 rounded-[12px] bg-alain-yellow text-alain-blue font-semibold">Get started</a>
+            <a href="/tutorials" className="inline-flex items-center h-11 px-5 rounded-[12px] border border-ink-100 bg-white text-ink-900">Browse tutorials</a>
+          </div>
+        </div>
+        <div className="rounded-card border border-ink-100 bg-paper-0 p-5 shadow-card">
+          <div className="font-display font-semibold text-[18px] text-ink-900">Why ALAIN</div>
+          <ul className="mt-3 space-y-2 text-ink-700 text-[15px]">
+            <li>• Build real skills with hands-on steps and checks</li>
+            <li>• Use one request shape across hosted and local providers</li>
+            <li>• Export clean notebooks with no embedded secrets</li>
+          </ul>
         </div>
       </section>
 
+      {/* How it works */}
       <section className="grid md:grid-cols-3 gap-6 items-start">
-        <div className="p-6 rounded-card bg-paper-0 border border-ink-100 space-y-2 shadow-card">
-          <h3 className="font-display font-semibold text-[20px] leading-[28px] tracking-tight">Paste</h3>
-          <p className="font-inter text-ink-700">Drop a Hugging Face link or choose a local model.</p>
-        </div>
-        <div className="p-6 rounded-card bg-paper-0 border border-ink-100 space-y-2 shadow-card">
-          <h3 className="font-display font-semibold text-[20px] leading-[28px] tracking-tight">Generate</h3>
-          <p className="font-inter text-ink-700">ALAIN builds a leveled lab with guardrails and quick checks.</p>
-        </div>
-        <div className="p-6 rounded-card bg-paper-0 border border-ink-100 space-y-2 shadow-card">
-          <h3 className="font-display font-semibold text-[20px] leading-[28px] tracking-tight">Run anywhere</h3>
-          <p className="font-inter text-ink-700">Export to Colab/Jupyter; switch hosted ↔ local with the same API shape.</p>
-        </div>
+        <HomeCard title="1. Paste a model link" text="Enter a Hugging Face URL or owner/repo, or select a local model." />
+        <HomeCard title="2. Generate a lesson" text="ALAIN creates a guided notebook with setup, examples, and quick checks." />
+        <HomeCard title="3. Run and export" text="Stream results, inspect requests, and export to Colab or Jupyter." />
+      </section>
+
+      {/* Audience */}
+      <section className="grid md:grid-cols-3 gap-6 items-start">
+        <HomeCard title="For teams" text="Evaluate models with the same template and clear requests." subtle />
+        <HomeCard title="For educators" text="Design labs that students can run and verify in minutes." subtle />
+        <HomeCard title="For builders" text="Ship tutorials that users can trust and reuse." subtle />
       </section>
     </div>
   );
 }
 
+function HomeCard({ title, text, subtle }: { title: string; text: string; subtle?: boolean }) {
+  return (
+    <div className={`p-6 rounded-card border ${subtle ? 'border-ink-100 bg-paper-0' : 'border-ink-100 bg-paper-0'} space-y-2 shadow-card`}>
+      <h3 className="font-display font-semibold text-[20px] leading-[28px] tracking-tight">{title}</h3>
+      <p className="font-inter text-ink-700">{text}</p>
+    </div>
+  );
+}

--- a/web/lib/schemas.ts
+++ b/web/lib/schemas.ts
@@ -45,6 +45,15 @@ export const ExportNotebookSchema = z.object({
   metadata: z.record(z.any()).optional(),
 });
 
+// Hugging Face Model Info (as returned by our web API proxy)
+export const HFModelInfoSchema = z.object({
+  license: z.string().nullable().optional(),
+  tags: z.array(z.string()).default([]),
+  downloads: z.number().nullable().optional(),
+});
+
+export type HFModelInfo = z.infer<typeof HFModelInfoSchema>;
+
 export type ProviderInfo = z.infer<typeof ProviderInfoSchema>;
 export type ProvidersResponse = z.infer<typeof ProvidersResponseSchema>;
 export type GenerateSuccess = z.infer<typeof GenerateSuccessSchema>;
@@ -56,4 +65,3 @@ export function isSuccessEnvelope(x: unknown): x is GenerateSuccess {
   const r = GenerateSuccessSchema.safeParse(x);
   return r.success;
 }
-


### PR DESCRIPTION
Adds a typed HF model-info schema and client helper, a small inline info card on the Generate HF tab, and unit tests. No license notices or gating. Keeps UI clean and functional.