### PR TITLE
feat(web): new shell applied to Tutorials and Settings

### DIFF
--- a/docs/NEW_UI_P0_NOTES.md
+++ b/docs/NEW_UI_P0_NOTES.md
@@ -4,7 +4,7 @@ This document summarizes the P0 implementation work, feature flags, and how to v
 
 ## What changed
 - New page: `/home` — simplified hero + clear CTAs.
-- New shell applied to default `/generate` via a route group layout `(app)`; legacy kept at `/v1/generate`.
+- New shell applied to default `/generate`, `/tutorials`, `/tutorial/[id]`, and `/settings` via a route group layout `(app)`; legacy Generate kept at `/v1/generate`.
 - NavBar links now point to `/generate` (new shell) directly. Optional `New Home` link is still flag‑gated.
 - Generate page:
   - Hides the "Force fallback mode" checkbox unless `NEXT_PUBLIC_ENABLE_FALLBACK_UI=1`.

--- a/web/app/(app)/settings/page.tsx
+++ b/web/app/(app)/settings/page.tsx
@@ -1,0 +1,6 @@
+export const metadata = {
+  title: 'ALAIN — Settings',
+};
+
+export { default } from '../../../settings/page';
+

--- a/web/app/(app)/tutorial/[id]/page.tsx
+++ b/web/app/(app)/tutorial/[id]/page.tsx
@@ -1,0 +1,2 @@
+export { default } from '../../../../tutorial/[id]/page';
+

--- a/web/app/(app)/tutorials/page.tsx
+++ b/web/app/(app)/tutorials/page.tsx
@@ -1,0 +1,6 @@
+export const metadata = {
+  title: 'ALAIN — Tutorials',
+};
+
+export { default } from '../../../tutorials/page';
+


### PR DESCRIPTION
Moves Tutorials (list + detail) and Settings under the (app) route group so they render in the same shell as Generate. No functional changes, just consistent layout. Unit tests remain green.