### PR TITLE
feat(env): .env onboarding + ALAIN branding; mirror in backend

### DIFF
--- a/backend/execution/lesson-generator.ts
+++ b/backend/execution/lesson-generator.ts
@@ -400,7 +400,7 @@ async function teacherGenerateWithRetry(args: Parameters<typeof teacherGenerate>
 // Extract model information from Hugging Face URL
 export async function extractHFModelInfo(hfUrl: string) {
   // Strict HF parsing and host allowlisting
-  let ref: ReturnType<typeof parseHfUrl>;
+  let ref: import('../utils/hf').HfModelRef;
   try {
     ref = parseHfUrl(hfUrl);
   } catch {


### PR DESCRIPTION
This PR:

- Adds beginner-friendly .env primer + loader cells to SDK notebooks (loads .env.local → .env; prompts for missing keys; optional masked recap)
- Loads envs consistently in CLI and documents behavior in README
- Mirrors early env detection, .env primer + loader into backend/export notebooks
- Maps POE_API_KEY to OpenAI-compatible env and adds 1-token smoke test
- Adds visible ALAIN (Applied Learning AI Notebooks) branding cell near the top of SDK notebooks

Encore compile fix:
- Replaces ReturnType-based exported types in observability with explicit interfaces
- Replaces ReturnType usage in lesson-generator with HfModelRef explicitly

Notes:
- CLI seeds <outDir>/.env.local.example only if no .env files exist
- README includes a short '.env Best Practices' section

Please review placement and copy; happy to tweak wording.

## Summary by Sourcery

Implement comprehensive .env onboarding across SDK notebooks, CLI, and backend with interactive prompts and best practices documentation; add ALAIN branding to SDK notebooks; map POE_API_KEY to an OpenAI API key with a smoke test; and refactor ReturnType-based types to explicit interfaces for compile stability.

New Features:
- Add .env primer and dynamic loader cells to SDK notebooks for beginner-friendly environment setup
- Mirror early .env primer and loader in backend/export notebooks
- Add visible ALAIN branding cell near the top of SDK notebooks
- Map POE_API_KEY to an OpenAI-compatible environment variable

Enhancements:
- Consistently load environment variables in the CLI and seed .env.local.example when no .env files exist
- Replace ReturnType-based types with explicit interfaces in observability and lesson-generator to fix compile issues

Documentation:
- Document .env loading behavior and best practices in the README

Tests:
- Add a 1-token smoke test for the OpenAI-compatible API key