### PR TITLE
Fix notebook ID handling and Clerk imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm run test:pure
 
       - name: Build web
-        working-directory: web
+        working-directory: apps/web
         env:
           NEXT_TELEMETRY_DISABLED: '1'
         run: |

--- a/apps/web/__tests__/notebook-id.test.ts
+++ b/apps/web/__tests__/notebook-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { encodeNotebookId, decodeNotebookParam } from '../lib/notebookId';
+
+describe('notebook id helpers', () => {
+  it('encodes notebook IDs with reserved characters', () => {
+    expect(encodeNotebookId('gh:owner/repo@main:path/to/file.ipynb')).toBe('gh%3Aowner%2Frepo%40main%3Apath%2Fto%2Ffile.ipynb');
+  });
+
+  it('decodes notebook route params', () => {
+    const encoded = 'gh%3Aowner%2Frepo%40main%3Apath%2Ffile.ipynb';
+    expect(decodeNotebookParam(encoded)).toBe('gh:owner/repo@main:path/file.ipynb');
+  });
+
+  it('returns original string when decode fails', () => {
+    const raw = '%E0%A4%A';
+    expect(decodeNotebookParam(raw)).toBe(raw);
+  });
+});

--- a/apps/web/app/api/notebooks/remix/alain/route.ts
+++ b/apps/web/app/api/notebooks/remix/alain/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
 import { putNotebook, getNotebook, type NotebookMeta } from '@/lib/notebookStore';
 import { parseGhId, fetchPublicNotebook } from '@/lib/githubRaw';
 
@@ -54,6 +55,10 @@ function extractPlainText(nb: any, maxChars = 8000): string {
 
 export async function POST(req: Request) {
   try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
     const body = await req.json().catch(() => ({} as ReqBody)) as ReqBody;
     const id = (body.id || '').trim();
     const baseUrl = (body.baseUrl || process.env.OPENAI_BASE_URL || '').replace(/\/$/, '') || 'http://localhost:1234';

--- a/apps/web/app/notebooks/[id]/edit/page.tsx
+++ b/apps/web/app/notebooks/[id]/edit/page.tsx
@@ -3,12 +3,13 @@ import React, { useEffect, useMemo, useState } from "react";
 import CodeEditor from "@/components/CodeEditor";
 import MarkdownEditor from "@/components/MarkdownEditor";
 import { useParams, useRouter } from "next/navigation";
+import { decodeNotebookParam, encodeNotebookId } from "@/lib/notebookId";
 
 export default function EditNotebookPage() {
   const { id: rawId } = useParams<{ id: string }>();
-  const id = (() => { try { return decodeURIComponent(rawId); } catch { return rawId; } })();
+  const id = decodeNotebookParam(rawId);
   const router = useRouter();
-  const encodedId = encodeURIComponent(id);
+  const encodedId = encodeNotebookId(id);
   const [jsonText, setJsonText] = useState<string>("{}");
   const [cells, setCells] = useState<any[]>([]);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/app/notebooks/[id]/page.tsx
+++ b/apps/web/app/notebooks/[id]/page.tsx
@@ -1,19 +1,19 @@
 import NotebookViewer from "@/components/NotebookViewer";
 import NotebookActions from "@/components/NotebookActions";
 import { appBaseUrl } from "@/lib/requestBase";
+import { decodeNotebookParam, encodeNotebookId } from "@/lib/notebookId";
 
 export const dynamic = "force-dynamic";
 
 async function fetchNotebook(id: string) {
   const base = appBaseUrl();
-  const res = await fetch(`${base}/api/notebooks/${encodeURIComponent(id)}`, { cache: "no-store" });
+  const res = await fetch(`${base}/api/notebooks/${encodeNotebookId(id)}`, { cache: "no-store" });
   if (!res.ok) return null;
   return res.json();
 }
 
 export default async function NotebookPage({ params, searchParams }: { params: { id: string }, searchParams?: { [k: string]: string | string[] | undefined } }) {
-  let decodedId: string;
-  try { decodedId = decodeURIComponent(params.id); } catch { decodedId = params.id; }
+  const decodedId = decodeNotebookParam(params.id);
   const rec = await fetchNotebook(decodedId);
   if (!rec) {
     return <div className="mx-auto max-w-3xl p-6">Notebook not found.</div>;

--- a/apps/web/components/GitHubOpenForm.tsx
+++ b/apps/web/components/GitHubOpenForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { toGhId } from "@/lib/githubNotebook";
+import { encodeNotebookId } from "@/lib/notebookId";
 
 export default function GitHubOpenForm({ defaultRemix }: { defaultRemix?: boolean }) {
   const [url, setUrl] = useState('');
@@ -11,7 +12,7 @@ export default function GitHubOpenForm({ defaultRemix }: { defaultRemix?: boolea
       setErr(null);
       const id = toGhId(url);
       if (!id) { setErr('Enter a valid GitHub .ipynb URL'); return; }
-      const target = `/notebooks/${encodeURIComponent(id)}${defaultRemix ? '?remix=1' : ''}`;
+      const target = `/notebooks/${encodeNotebookId(id)}${defaultRemix ? '?remix=1' : ''}`;
       window.location.assign(target);
     }}>
       <div className="grow min-w-[260px]">
@@ -20,7 +21,7 @@ export default function GitHubOpenForm({ defaultRemix }: { defaultRemix?: boolea
         {err && <div className="text-xs text-red-600 mt-1">{err}</div>}
       </div>
       <button type="submit" className="inline-flex items-center h-9 px-3 rounded bg-ink-900 text-white">Open</button>
-      <button type="button" onClick={() => { const id = toGhId(url); if (!id) { setErr('Enter a valid GitHub .ipynb URL'); return; } const target = `/notebooks/${encodeURIComponent(id)}?remix=1`; window.location.assign(target); }} className="inline-flex items-center h-9 px-3 rounded bg-alain-yellow text-alain-blue font-semibold">Remix</button>
+      <button type="button" onClick={() => { const id = toGhId(url); if (!id) { setErr('Enter a valid GitHub .ipynb URL'); return; } const target = `/notebooks/${encodeNotebookId(id)}?remix=1`; window.location.assign(target); }} className="inline-flex items-center h-9 px-3 rounded bg-alain-yellow text-alain-blue font-semibold">Remix</button>
     </form>
   );
 }

--- a/apps/web/components/NavBar.tsx
+++ b/apps/web/components/NavBar.tsx
@@ -2,8 +2,7 @@
 import Link from "next/link";
 import BrandLogo from "./BrandLogo";
 import MobileNav from "./MobileNav";
-import { useUser } from "@clerk/nextjs";
-import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
+import { SignInButton, SignedIn, SignedOut, UserButton, useUser } from "@clerk/nextjs";
 
 export default function NavBar() {
   const { user } = useUser();

--- a/apps/web/components/NotebookActions.tsx
+++ b/apps/web/components/NotebookActions.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useState } from "react";
 import { useRouter } from "next/navigation";
+import { encodeNotebookId } from "@/lib/notebookId";
 
 export default function NotebookActions({ id, promptRemix }: { id: string; promptRemix?: boolean }) {
   const [toast, setToast] = useState<string | null>(null);
@@ -17,7 +18,7 @@ export default function NotebookActions({ id, promptRemix }: { id: string; promp
   const [model, setModel] = useState<string>('openai/gpt-oss-20b');
   const [maxSections, setMaxSections] = useState<number>(8);
   const router = useRouter();
-  const encodedId = encodeURIComponent(id);
+  const encodedId = encodeNotebookId(id);
   const isGh = id.startsWith('gh:');
   async function exportPR() {
     try {
@@ -97,8 +98,7 @@ export default function NotebookActions({ id, promptRemix }: { id: string; promp
                     setShowRemix(false);
                     setToast('Remix ready');
                     if (newId) {
-                      // Use encodeURIComponent to keep gh:/slashes safe
-                      router.push(`/notebooks/${encodeURIComponent(newId)}`);
+                      router.push(`/notebooks/${encodeNotebookId(newId)}`);
                     }
                   } catch (e: any) {
                     setToast(e?.message || 'Remix failed');
@@ -146,7 +146,7 @@ export default function NotebookActions({ id, promptRemix }: { id: string; promp
                     const newId = j?.id;
                     setShowAlainRemix(false);
                     setToast('Remix ready');
-                    if (newId) router.push(`/notebooks/${encodeURIComponent(newId)}`);
+                    if (newId) router.push(`/notebooks/${encodeNotebookId(newId)}`);
                   } catch (e: any) {
                     setToast(e?.message || 'Remix failed');
                   } finally {

--- a/apps/web/components/NotebookViewer.tsx
+++ b/apps/web/components/NotebookViewer.tsx
@@ -1,5 +1,8 @@
 "use client";
 import React, { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeSanitize from "rehype-sanitize";
 import { runPython } from "./PyRunner";
 import { runJS } from "./JSRunner";
 
@@ -7,7 +10,15 @@ type Props = { nb: any };
 
 function MarkdownCell({ source }: { source: string | string[] }) {
   const text = Array.isArray(source) ? source.join("") : source;
-  return <div className="prose prose-invert max-w-none" dangerouslySetInnerHTML={{ __html: text.replace(/\n/g, "<br/>") }} />;
+  return (
+    <ReactMarkdown
+      className="prose prose-invert max-w-none"
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeSanitize]}
+    >
+      {text}
+    </ReactMarkdown>
+  );
 }
 
 function CodeCell({ source, lang }: { source: string | string[]; lang?: string }) {

--- a/apps/web/lib/notebookId.ts
+++ b/apps/web/lib/notebookId.ts
@@ -1,0 +1,11 @@
+export function encodeNotebookId(id: string): string {
+  return encodeURIComponent(id);
+}
+
+export function decodeNotebookParam(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,6 +18,9 @@
         "next": "^14.2.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-markdown": "^9.0.1",
+        "rehype-sanitize": "^5.0.1",
+        "remark-gfm": "^4.0.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -5051,6 +5054,34 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-sanitize": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-4.1.0.tgz",
+      "integrity": "sha512-Hd9tU0ltknMGRDv+d6Ro/4XKzBqQnP/EZrpiTbpFYfXv/uOhWeKc+2uajcbEvAEH98VZd7eII2PiXm13RihnLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/hast-util-sanitize/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/hast-util-select": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-select/-/hast-util-select-6.0.4.tgz",
@@ -5469,6 +5500,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/is-bun-module": {
@@ -8425,6 +8479,98 @@
       },
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-5.0.1.tgz",
+      "integrity": "sha512-da/jIOjq8eYt/1r9GN6GwxIR3gde7OZ+WV8pheu1tL8K0D9KxM2AyMh+UEfke+FfdM3PvGHeYJU0Td5OWa7L5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-sanitize": "^4.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize/node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
+    "node_modules/rehype-sanitize/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/rehype-sanitize/node_modules/unified": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+      "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "bail": "^2.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize/node_modules/unist-util-stringify-position": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.3.tgz",
+      "integrity": "sha512-k5GzIBZ/QatR8N5X2y+drfpWG8IDBzdnVj6OInRNWm1oXrzydiaAT2OQiA8DPRRZyAKb9b6I2a6PxYklZD0gKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize/node_modules/vfile": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.7.tgz",
+      "integrity": "sha512-r7qlzkgErKjobAmyNIkkSpizsFPYiUPuJb5pNW1RB4JcYVZhs4lIbVqk8XPk033CV/1z8ss5pkax8SuhGpcG8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0",
+        "vfile-message": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize/node_modules/vfile-message": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.4.tgz",
+      "integrity": "sha512-fa0Z6P8HUrQN4BZaX05SIVXic+7kE3b05PWAtPuYP9QLHsLKYR7/AlLW3NtOrpXRLeawpDLMsVkmk5DG0NXgWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rehype-slug": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,7 +25,7 @@
     "zod": "^3.23.8",
     "monaco-editor": "^0.52.0",
     "jszip": "^3.10.1",
-    "rehype-sanitize": "^6.0.1",
+    "rehype-sanitize": "^5.0.1",
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,9 +21,12 @@
     "next": "^14.2.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
     "zod": "^3.23.8",
     "monaco-editor": "^0.52.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "rehype-sanitize": "^6.0.1",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.19",


### PR DESCRIPTION
## Summary by Sourcery

Clean up JSRunner resources, upgrade Markdown rendering, centralize notebook ID handling across the app, enforce auth on the alain remix API, and update dependencies.

Bug Fixes:
- Terminate workers and revoke object URLs to prevent memory leaks in JSRunner
- Return 401 when user is not authenticated in the alain remix API route

Enhancements:
- Return blob URL with workers and revoke it to manage resources
- Switch NotebookViewer to use ReactMarkdown with GFM support and sanitization
- Add encodeNotebookId and decodeNotebookParam utilities and replace inline encoding/decoding throughout
- Consolidate Clerk imports in NavBar into a single grouped import

Build:
- Add react-markdown, remark-gfm, and rehype-sanitize dependencies

Tests:
- Add unit tests for notebook ID encoding and decoding